### PR TITLE
Add is_power_of_2 function to check number of Fourier mode satisfies 2^n

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -177,8 +177,7 @@ function Kcoordgen(
         kval(indices[axis], ngrid, xrange)
     )
 
-    flag_ngrid_power_of_2 = is_power_of_2(ngrid)
-    if !flag_ngrid_power_of_2
+    if !is_power_of_2(ngrid)
         println("WARNING: ngrid[", axis, "]= ", ngrid, " should be power of 2 for FFTW efficiency")
     end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -177,7 +177,7 @@ function Kcoordgen(
         kval(indices[axis], ngrid, xrange)
     )
 
-    flag_ngrid_power_of_2 = is_good_ngrid(ngrid)
+    flag_ngrid_power_of_2 = is_power_of_2(ngrid)
     if !flag_ngrid_power_of_2
         println("WARNING: ngrid[", axis, "]= ", ngrid, " should be power of 2 for FFTW efficiency")
     end
@@ -202,16 +202,17 @@ end
 """
 For FFTW efficiency, returns warning if ngrid is not a power of 2
 """
-function is_good_ngrid(ngrid)
+function is_power_of_2(num::Int)
 
-    flag_ngrid_power_of_2::Bool = false
-    for power in 0:20
-        if 2^power == ngrid
-            flag_ngrid_power_of_2 = true
-        end
+    if num<=0
+        errmsg="ngrid must be >0"
+        throw(DomainError(num, errmsg))
+    elseif num%2!=0
+        return num==1
+    else
+        return is_power_of_2(num÷2)
     end
 
-    return flag_ngrid_power_of_2
 end
 
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -177,6 +177,8 @@ function Kcoordgen(
         kval(indices[axis], ngrid, xrange)
     )
 
+    check_ngrid(ngrid)
+
     return _Kcoordgen.(CartesianIndices(ngrids))
 
 end
@@ -192,6 +194,22 @@ function kval(index, ngrid, xrange)::Complex{Float64}
         return index0 - ngrid
     end
 
+end
+
+"""
+For FFTW efficiency, returns warning if ngrid is not a power of 2
+"""
+function check_ngrid(ngrid)
+
+    flag_ngrid::Bool = false
+    for power in 0:20
+        if 2^power == ngrid
+            flag_ngrid = true
+        end
+    end
+    if !flag_ngrid
+        println("WARNING: ngrid= ", ngrid, " should be power of 2 for FFTW efficiency")
+    end
 end
 
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -177,7 +177,10 @@ function Kcoordgen(
         kval(indices[axis], ngrid, xrange)
     )
 
-    check_ngrid(ngrid)
+    flag_ngrid = is_good_ngrid(ngrid)
+    if !flag_ngrid
+        println("WARNING: ngrid[", axis, "]= ", ngrid, " should be power of 2 for FFTW efficiency")
+    end
 
     return _Kcoordgen.(CartesianIndices(ngrids))
 
@@ -199,7 +202,7 @@ end
 """
 For FFTW efficiency, returns warning if ngrid is not a power of 2
 """
-function check_ngrid(ngrid)
+function is_good_ngrid(ngrid)
 
     flag_ngrid::Bool = false
     for power in 0:20
@@ -207,9 +210,8 @@ function check_ngrid(ngrid)
             flag_ngrid = true
         end
     end
-    if !flag_ngrid
-        println("WARNING: ngrid= ", ngrid, " should be power of 2 for FFTW efficiency")
-    end
+
+    return flag_ngrid
 end
 
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -177,8 +177,8 @@ function Kcoordgen(
         kval(indices[axis], ngrid, xrange)
     )
 
-    flag_ngrid = is_good_ngrid(ngrid)
-    if !flag_ngrid
+    flag_ngrid_power_of_2 = is_good_ngrid(ngrid)
+    if !flag_ngrid_power_of_2
         println("WARNING: ngrid[", axis, "]= ", ngrid, " should be power of 2 for FFTW efficiency")
     end
 
@@ -204,14 +204,14 @@ For FFTW efficiency, returns warning if ngrid is not a power of 2
 """
 function is_good_ngrid(ngrid)
 
-    flag_ngrid::Bool = false
+    flag_ngrid_power_of_2::Bool = false
     for power in 0:20
         if 2^power == ngrid
-            flag_ngrid = true
+            flag_ngrid_power_of_2 = true
         end
     end
 
-    return flag_ngrid
+    return flag_ngrid_power_of_2
 end
 
 


### PR DESCRIPTION
For issue https://github.com/mat-der-D/SpectralMethodFFT.jl/issues/4#issue-702655714
To check whether the ngrid is a power of 2.
If not, returns warning.